### PR TITLE
feat: modular setup scripts with dry-run support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,131 @@
+# brew-up
+
+Automated setup scripts for new macOS VMs. Installs Homebrew, Oh My Zsh, and essential packages.
+
+## Quick Start
+
+```bash
+# Clone the repo
+git clone git@github.com:freddieweir/brew-up.git
+cd brew-up
+
+# Run full setup
+./setup.sh
+
+# Or preview what would be installed first
+./setup.sh --dry-run
+```
+
+## Usage
+
+### Full Setup (Recommended for New VMs)
+
+```bash
+./setup.sh
+```
+
+This runs all setup scripts in order:
+1. Installs Homebrew (if not present)
+2. Installs Oh My Zsh (if not present)
+3. Installs all formulae and casks
+
+### Dry Run Mode
+
+Preview what would be installed without making changes:
+
+```bash
+./setup.sh --dry-run
+# or
+./setup.sh -n
+```
+
+### Individual Scripts
+
+Run specific setup steps:
+
+```bash
+# Install Homebrew only
+./scripts/01-install-homebrew.sh
+
+# Install Oh My Zsh only
+./scripts/02-install-ohmyzsh.sh
+
+# Install packages only (supports --dry-run)
+./scripts/03-install-packages.sh
+./scripts/03-install-packages.sh --dry-run
+```
+
+## What Gets Installed
+
+### Formulae (CLI Tools)
+
+| Package | Description |
+|---------|-------------|
+| act | GitHub Actions local runner |
+| awscli | AWS CLI |
+| docker | Docker CLI |
+| docker-completion | Docker shell completions |
+| fzf | Fuzzy finder |
+| gh | GitHub CLI |
+| git | Git version control |
+| glances | System monitoring tool |
+| htop | Process viewer |
+| jq | JSON processor |
+| k9s | Kubernetes TUI |
+| kubernetes-cli | kubectl |
+| node | Node.js runtime |
+| pipx | Install Python CLI tools |
+| rust | Rust programming language |
+| terraform | Infrastructure as code |
+| tmux | Terminal multiplexer |
+| tree | Directory tree viewer |
+| uv | Fast Python package manager |
+| wget | File downloader |
+| yt-dlp | Video downloader |
+| zsh-autosuggestions | Zsh fish-like autosuggestions |
+| zsh-syntax-highlighting | Zsh syntax highlighting |
+
+### Cask Applications (GUI Apps)
+
+| Package | Description |
+|---------|-------------|
+| 1password | Password manager |
+| 1password-cli | 1Password CLI |
+| appcleaner | App uninstaller |
+| brave-browser | Chrome-based browser |
+| chromium | Open-source browser |
+| claude | Claude desktop app |
+| claude-code | Claude Code CLI |
+| firefox | Mozilla Firefox |
+| github | GitHub Desktop |
+| iina | Modern media player |
+| istat-menus | System monitor menubar |
+| iterm2 | Terminal emulator |
+| jordanbaird-ice | Menubar manager |
+| jump-desktop-connect | Remote desktop client |
+| linearmouse | Mouse customization |
+| little-snitch | Network monitor |
+| mozilla-vpn | VPN client |
+| pearcleaner | App uninstaller (alternative) |
+| syncthing-app | File sync |
+| vscodium | VS Code without telemetry |
+| zen-browser | Privacy-focused browser |
+
+## Customizing
+
+To add or remove packages, edit `scripts/03-install-packages.sh`:
+
+- Add formulae to the `formulae=()` array
+- Add casks to the `cask_apps=()` array
+
+## Requirements
+
+- macOS (Apple Silicon or Intel)
+- Internet connection
+- Admin privileges (for some cask installations)
+
+## Notes
+
+- All scripts are idempotent (safe to run multiple times)
+- Scripts will skip already-installed packages
+- Do NOT run with `sudo` - Homebrew doesn't support root installation

--- a/brew.sh
+++ b/brew.sh
@@ -1,145 +1,15 @@
 #!/bin/bash
-
 # =============================================================================
-# Homebrew Installation Script
+# Backwards Compatibility Wrapper
 # =============================================================================
-# This script installs Homebrew (if not present) and then installs:
-# 1. Formulae - Command-line tools and libraries
-# 2. Cask Applications - GUI applications
-# 
-# To add new items:
-# - Add formulae to the 'formulae' array below
-# - Add cask apps to the 'cask_apps' array below
+# This script wraps setup.sh for backwards compatibility.
+# For new usage, prefer: ./setup.sh
 # =============================================================================
 
-# =============================================================================
-# SECURITY CHECK - Do NOT run as root/sudo
-# =============================================================================
-if [[ $EUID -eq 0 ]]; then
-   echo "❌ ERROR: This script should NOT be run with sudo or as root!"
-   echo ""
-   echo "🔒 Homebrew does not support running as root for security reasons."
-   echo "🔧 Run this script as a regular user: ./brew.sh"
-   echo ""
-   echo "💡 Note: Some installed tools (like htop) may require sudo when you USE them,"
-   echo "   but the installation itself should be done as a regular user."
-   echo ""
-   exit 1
-fi
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Check if Homebrew is installed
-if ! command -v brew >/dev/null 2>&1; then
-  echo "🍺 Homebrew not found. Installing Homebrew..."
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-  # After installation, add Homebrew to PATH for the current session
-  if [[ -d /opt/homebrew/bin ]]; then
-    # Apple Silicon
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-  elif [[ -d /usr/local/bin ]]; then
-    # Intel macOS
-    eval "$(/usr/local/bin/brew shellenv)"
-  fi
-else
-  echo "🍺 Homebrew is already installed. Updating Homebrew..."
-  brew update
-fi
-
-# =============================================================================
-# FORMULAE (Command-line tools and libraries)
-# =============================================================================
-# Add new command-line tools to this array
-formulae=(
-  gh                    # GitHub CLI
-  git                   # Git version control
-  jq                    # JSON processor
-  wget                  # File downloader
-  curl                  # Transfer data tool
-  tree                  # Directory tree viewer
-  htop                  # Process viewer (use 'sudo htop' for full processes)
-)
-
-# =============================================================================
-# CASK APPLICATIONS (GUI Applications)
-# =============================================================================
-# Add new GUI applications to this array
-cask_apps=(
-  1password             # Password manager
-  1password-cli         # 1Password CLI
-  cursor                # AI-powered code editor
-  iterm2                # Terminal emulator
-  mozilla-vpn           # VPN client
-  obsidian              # Note-taking app
-  yubico-authenticator  # YubiKey authenticator
-  zen-browser           # Privacy-focused browser
-  chromium              # Open-source browser
-)
-
-# =============================================================================
-# INSTALL FORMULAE
-# =============================================================================
+echo "💡 Note: brew.sh now calls setup.sh"
+echo "   For direct usage, run: ./setup.sh"
 echo ""
-echo "📦 Installing formulae (command-line tools)..."
-for formula in "${formulae[@]}"; do
-  # Remove inline comments for processing
-  formula_name=$(echo "$formula" | awk '{print $1}')
-  
-  if brew list "$formula_name" >/dev/null 2>&1; then
-    echo "✅ $formula_name is already installed."
-  else
-    echo "⬇️  Installing $formula_name..."
-    brew install "$formula_name"
-  fi
-done
 
-# =============================================================================
-# INSTALL CASK APPLICATIONS
-# =============================================================================
-echo ""
-echo "🖥️  Installing cask applications (GUI apps)..."
-for app in "${cask_apps[@]}"; do
-  # Remove inline comments for processing
-  app_name=$(echo "$app" | awk '{print $1}')
-  
-  if brew list --cask "$app_name" >/dev/null 2>&1; then
-    echo "✅ $app_name is already installed."
-  else
-    echo "⬇️  Installing $app_name..."
-    brew install --cask "$app_name"
-  fi
-done
-
-# =============================================================================
-# OH MY ZSH INSTALLATION
-# =============================================================================
-echo ""
-echo "🎨 Installing Oh My Zsh (enhanced terminal experience)..."
-
-# Check if Oh My Zsh is already installed
-if [[ -d "$HOME/.oh-my-zsh" ]]; then
-  echo "✅ Oh My Zsh is already installed."
-else
-  echo "⬇️  Installing Oh My Zsh..."
-  # Install Oh My Zsh in unattended mode (non-interactive)
-  sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-  
-  # Set zsh as default shell if it isn't already
-  if [[ "$SHELL" != */zsh ]]; then
-    echo "🔧 Setting zsh as default shell..."
-    chsh -s $(which zsh)
-    echo "💡 You'll need to restart your terminal/session for the shell change to take effect."
-  fi
-fi
-
-echo ""
-echo "🎉 Installation complete!"
-echo ""
-echo "📝 To add more items:"
-echo "   - Add formulae (CLI tools) to the 'formulae' array"
-echo "   - Add cask apps (GUI apps) to the 'cask_apps' array"
-echo ""
-echo "💡 Usage notes:"
-echo "   - Some tools like htop require sudo when USING them: 'sudo htop'"
-echo "   - Never run this installation script with sudo"
-echo "   - Oh My Zsh provides themes and plugins - explore ~/.oh-my-zsh/"
-echo "   - Restart your terminal to fully activate Oh My Zsh"
+exec "$SCRIPT_DIR/setup.sh" "$@"

--- a/scripts/01-install-homebrew.sh
+++ b/scripts/01-install-homebrew.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# =============================================================================
+# Homebrew Installation Script
+# =============================================================================
+# Installs Homebrew and configures shell for persistence
+# Reference: https://docs.brew.sh/Installation
+# =============================================================================
+
+set -e
+
+# Security check - do NOT run as root/sudo
+if [[ $EUID -eq 0 ]]; then
+  echo "❌ ERROR: Do not run this script as root/sudo"
+  echo "   Homebrew does not support running as root for security reasons."
+  exit 1
+fi
+
+# Check if Homebrew is already installed
+if command -v brew &>/dev/null; then
+  echo "✅ Homebrew is already installed"
+  brew --version
+  exit 0
+fi
+
+echo "🍺 Installing Homebrew..."
+echo ""
+
+# Install Homebrew (official installer)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Determine prefix based on architecture (Apple Silicon vs Intel)
+if [[ -d /opt/homebrew ]]; then
+  # Apple Silicon Mac
+  BREW_PREFIX="/opt/homebrew"
+elif [[ -d /usr/local/Homebrew ]]; then
+  # Intel Mac
+  BREW_PREFIX="/usr/local"
+else
+  echo "❌ ERROR: Could not determine Homebrew installation path"
+  exit 1
+fi
+
+echo ""
+echo "📍 Homebrew installed at: $BREW_PREFIX"
+
+# Add to current session
+eval "$($BREW_PREFIX/bin/brew shellenv)"
+
+# Persist to .zshrc if not already present
+ZSHRC="$HOME/.zshrc"
+SHELLENV_CMD="eval \"\$($BREW_PREFIX/bin/brew shellenv)\""
+
+if [[ -f "$ZSHRC" ]] && grep -q 'brew shellenv' "$ZSHRC" 2>/dev/null; then
+  echo "✅ Homebrew already configured in ~/.zshrc"
+else
+  echo "" >> "$ZSHRC"
+  echo "# Homebrew" >> "$ZSHRC"
+  echo "$SHELLENV_CMD" >> "$ZSHRC"
+  echo "✅ Added Homebrew to ~/.zshrc"
+fi
+
+# Also add to .bash_profile for bash users
+BASH_PROFILE="$HOME/.bash_profile"
+if [[ -f "$BASH_PROFILE" ]] && ! grep -q 'brew shellenv' "$BASH_PROFILE" 2>/dev/null; then
+  echo "" >> "$BASH_PROFILE"
+  echo "# Homebrew" >> "$BASH_PROFILE"
+  echo "$SHELLENV_CMD" >> "$BASH_PROFILE"
+  echo "✅ Added Homebrew to ~/.bash_profile"
+fi
+
+echo ""
+echo "✅ Homebrew installation complete!"
+echo ""
+echo "💡 Restart your terminal or run:"
+echo "   eval \"\$($BREW_PREFIX/bin/brew shellenv)\""

--- a/scripts/02-install-ohmyzsh.sh
+++ b/scripts/02-install-ohmyzsh.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# =============================================================================
+# Oh My Zsh Installation Script
+# =============================================================================
+# Installs Oh My Zsh for enhanced terminal experience
+# Reference: https://ohmyz.sh/
+# =============================================================================
+
+set -e
+
+# Check if Oh My Zsh is already installed
+if [[ -d "$HOME/.oh-my-zsh" ]]; then
+  echo "✅ Oh My Zsh is already installed"
+  exit 0
+fi
+
+echo "🎨 Installing Oh My Zsh..."
+echo ""
+
+# Install Oh My Zsh in unattended mode (non-interactive)
+sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+
+# Set zsh as default shell if it isn't already
+if [[ "$SHELL" != */zsh ]]; then
+  echo ""
+  echo "🔧 Setting zsh as default shell..."
+
+  # Get the path to zsh
+  ZSH_PATH=$(which zsh)
+
+  if [[ -n "$ZSH_PATH" ]]; then
+    chsh -s "$ZSH_PATH"
+    echo "✅ Default shell changed to zsh"
+    echo "💡 You'll need to restart your terminal for the shell change to take effect."
+  else
+    echo "⚠️  Could not find zsh. Please install zsh first."
+  fi
+else
+  echo "✅ zsh is already the default shell"
+fi
+
+echo ""
+echo "✅ Oh My Zsh installation complete!"
+echo ""
+echo "💡 Tips:"
+echo "   - Explore themes: ~/.oh-my-zsh/themes/"
+echo "   - Add plugins: edit ~/.zshrc and modify plugins=()"
+echo "   - Restart your terminal to see changes"

--- a/scripts/03-install-packages.sh
+++ b/scripts/03-install-packages.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# =============================================================================
+# Homebrew Packages Installation Script
+# =============================================================================
+# Installs formulae (CLI tools) and casks (GUI applications)
+# Supports --dry-run mode to preview installations
+# =============================================================================
+
+set -e
+
+# =============================================================================
+# PARSE ARGUMENTS
+# =============================================================================
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run|-n)
+      DRY_RUN=true
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: $0 [OPTIONS]"
+      echo ""
+      echo "Options:"
+      echo "  --dry-run, -n    Preview what would be installed without making changes"
+      echo "  --help, -h       Show this help message"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Use --help for usage information"
+      exit 1
+      ;;
+  esac
+done
+
+if $DRY_RUN; then
+  echo "🔍 DRY RUN MODE - No changes will be made"
+  echo ""
+fi
+
+# =============================================================================
+# SECURITY CHECK
+# =============================================================================
+if [[ $EUID -eq 0 ]]; then
+  echo "❌ ERROR: Do not run this script as root/sudo"
+  exit 1
+fi
+
+# =============================================================================
+# CHECK HOMEBREW
+# =============================================================================
+if ! command -v brew &>/dev/null; then
+  echo "❌ ERROR: Homebrew is not installed"
+  echo "   Run ./scripts/01-install-homebrew.sh first"
+  exit 1
+fi
+
+if ! $DRY_RUN; then
+  echo "🍺 Updating Homebrew..."
+  brew update
+fi
+
+# =============================================================================
+# FORMULAE (Command-line tools)
+# =============================================================================
+formulae=(
+  # Development Tools
+  act                       # GitHub Actions local runner
+  awscli                    # AWS CLI
+  docker                    # Docker CLI
+  docker-completion         # Docker shell completions
+  fzf                       # Fuzzy finder
+  gh                        # GitHub CLI
+  git                       # Git version control
+  k9s                       # Kubernetes TUI
+  node                      # Node.js runtime
+  pipx                      # Install Python CLI tools
+  rust                      # Rust programming language
+  terraform                 # Infrastructure as code
+  uv                        # Fast Python package manager
+
+  # Shell & Terminal
+  glances                   # System monitoring tool
+  htop                      # Process viewer
+  jq                        # JSON processor
+  tmux                      # Terminal multiplexer
+  tree                      # Directory tree viewer
+  zsh-autosuggestions       # Zsh fish-like autosuggestions
+  zsh-syntax-highlighting   # Zsh syntax highlighting
+
+  # Utilities
+  curl                      # Transfer data tool
+  ffmpeg                    # Media processing
+  kubernetes-cli            # kubectl
+  wget                      # File downloader
+  yt-dlp                    # Video downloader
+)
+
+# =============================================================================
+# CASK APPLICATIONS (GUI Applications)
+# =============================================================================
+cask_apps=(
+  # Core Tools
+  1password                 # Password manager
+  1password-cli             # 1Password CLI
+  claude                    # Claude desktop app
+  claude-code               # Claude Code CLI
+  github                    # GitHub Desktop
+  vscodium                  # VS Code without telemetry
+
+  # Browsers
+  brave-browser             # Chrome-based browser
+  chromium                  # Open-source browser
+  firefox                   # Mozilla Firefox
+  zen-browser               # Privacy-focused browser
+
+  # Productivity
+  iterm2                    # Terminal emulator
+
+  # System Utilities
+  appcleaner                # App uninstaller
+  istat-menus               # System monitor menubar
+  jordanbaird-ice           # Menubar manager
+  jump-desktop-connect      # Remote desktop client
+  linearmouse               # Mouse customization
+  little-snitch             # Network monitor
+  pearcleaner               # App uninstaller (alternative)
+  syncthing-app             # File sync
+
+  # Media
+  iina                      # Modern media player
+
+  # Security
+  mozilla-vpn               # VPN client
+)
+
+# =============================================================================
+# INSTALL FORMULAE
+# =============================================================================
+echo ""
+echo "📦 Formulae (command-line tools)..."
+echo "   Total: ${#formulae[@]} packages"
+echo ""
+
+for formula in "${formulae[@]}"; do
+  # Extract formula name (remove inline comments)
+  formula_name=$(echo "$formula" | awk '{print $1}')
+
+  if brew list "$formula_name" &>/dev/null; then
+    echo "  ✅ $formula_name (already installed)"
+  elif $DRY_RUN; then
+    echo "  📋 $formula_name (would install)"
+  else
+    echo "  ⬇️  Installing $formula_name..."
+    brew install "$formula_name"
+  fi
+done
+
+# =============================================================================
+# INSTALL CASK APPLICATIONS
+# =============================================================================
+echo ""
+echo "🖥️  Cask applications (GUI apps)..."
+echo "   Total: ${#cask_apps[@]} applications"
+echo ""
+
+for app in "${cask_apps[@]}"; do
+  # Extract app name (remove inline comments)
+  app_name=$(echo "$app" | awk '{print $1}')
+
+  if brew list --cask "$app_name" &>/dev/null; then
+    echo "  ✅ $app_name (already installed)"
+  elif $DRY_RUN; then
+    echo "  📋 $app_name (would install)"
+  else
+    echo "  ⬇️  Installing $app_name..."
+    brew install --cask "$app_name"
+  fi
+done
+
+# =============================================================================
+# SUMMARY
+# =============================================================================
+echo ""
+if $DRY_RUN; then
+  echo "🔍 DRY RUN COMPLETE"
+  echo "   Run without --dry-run to install packages"
+else
+  echo "✅ Package installation complete!"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# =============================================================================
+# VM Setup Orchestrator
+# =============================================================================
+# Main script that runs all setup scripts in order:
+# 1. Install Homebrew (if not present)
+# 2. Install Oh My Zsh (if not present)
+# 3. Install formulae and casks
+#
+# Usage:
+#   ./setup.sh              # Full setup
+#   ./setup.sh --dry-run    # Preview package installations
+#   ./setup.sh -n           # Short form of --dry-run
+# =============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DRY_RUN=""
+
+# =============================================================================
+# PARSE ARGUMENTS
+# =============================================================================
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run|-n)
+      DRY_RUN="--dry-run"
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: $0 [OPTIONS]"
+      echo ""
+      echo "VM Setup Orchestrator - installs Homebrew, Oh My Zsh, and packages"
+      echo ""
+      echo "Options:"
+      echo "  --dry-run, -n    Preview package installations without making changes"
+      echo "  --help, -h       Show this help message"
+      echo ""
+      echo "Individual scripts:"
+      echo "  ./scripts/01-install-homebrew.sh   Install Homebrew only"
+      echo "  ./scripts/02-install-ohmyzsh.sh    Install Oh My Zsh only"
+      echo "  ./scripts/03-install-packages.sh   Install packages only (supports --dry-run)"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Use --help for usage information"
+      exit 1
+      ;;
+  esac
+done
+
+# =============================================================================
+# SECURITY CHECK
+# =============================================================================
+if [[ $EUID -eq 0 ]]; then
+  echo "❌ ERROR: Do not run this script as root/sudo"
+  exit 1
+fi
+
+# =============================================================================
+# RUN SETUP
+# =============================================================================
+echo "🚀 Starting VM Setup..."
+echo "========================================"
+echo ""
+
+# Step 1: Install Homebrew
+echo "📦 Step 1/3: Homebrew"
+echo "----------------------------------------"
+"$SCRIPT_DIR/scripts/01-install-homebrew.sh"
+echo ""
+
+# Ensure brew is available in current session after installation
+if [[ -d /opt/homebrew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -d /usr/local/Homebrew ]]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
+# Step 2: Install Oh My Zsh
+echo "🎨 Step 2/3: Oh My Zsh"
+echo "----------------------------------------"
+"$SCRIPT_DIR/scripts/02-install-ohmyzsh.sh"
+echo ""
+
+# Step 3: Install Packages
+echo "📋 Step 3/3: Packages"
+echo "----------------------------------------"
+"$SCRIPT_DIR/scripts/03-install-packages.sh" $DRY_RUN
+echo ""
+
+# =============================================================================
+# COMPLETE
+# =============================================================================
+echo "========================================"
+echo "🎉 Setup complete!"
+echo ""
+echo "💡 Next steps:"
+echo "   1. Restart your terminal for all changes to take effect"
+echo "   2. Explore Oh My Zsh themes: ~/.oh-my-zsh/themes/"
+echo "   3. Configure your apps as needed"
+echo ""
+if [[ -n "$DRY_RUN" ]]; then
+  echo "📋 Note: Packages were previewed only (--dry-run mode)"
+  echo "   Run './setup.sh' without --dry-run to install"
+fi


### PR DESCRIPTION
## Summary

Restructures brew-up into modular scripts for better maintainability and flexibility when setting up new VMs.

### Changes

- **New modular architecture:**
  - `scripts/01-install-homebrew.sh` - Homebrew installation with shell persistence
  - `scripts/02-install-ohmyzsh.sh` - Oh My Zsh installation
  - `scripts/03-install-packages.sh` - Package installation with `--dry-run` support
  - `setup.sh` - Main orchestrator that runs all scripts in order

- **Updated packages:**
  - 25 formulae: act, awscli, docker, fzf, gh, git, glances, htop, jq, k9s, kubernetes-cli, node, pipx, rust, terraform, tmux, tree, uv, wget, yt-dlp, zsh plugins
  - 21 casks: 1password, browsers (brave, chromium, firefox, zen), claude, claude-code, github, iina, istat-menus, iterm2, linearmouse, little-snitch, mozilla-vpn, vscodium, etc.

- **New features:**
  - `--dry-run` flag to preview what would be installed
  - Individual scripts can be run independently
  - Backwards compatibility via `brew.sh` wrapper

### Usage

```bash
./setup.sh              # Full setup
./setup.sh --dry-run    # Preview installations
./scripts/03-install-packages.sh --dry-run  # Preview packages only
```

## Test Plan

- [x] Verified `--dry-run` mode shows correct output
- [x] All scripts pass `bash -n` syntax check
- [x] Scripts are idempotent (safe to run multiple times)