### PR TITLE
feat: add Linux support with OS detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # brew-up
 
-Automated setup scripts for new macOS VMs. Installs Homebrew, Oh My Zsh, and essential packages.
+Automated setup scripts for new macOS/Linux machines. Installs Homebrew, Oh My Zsh, and essential packages.
 
 ## Quick Start
 
@@ -120,12 +120,13 @@ To add or remove packages, edit `scripts/03-install-packages.sh`:
 
 ## Requirements
 
-- macOS (Apple Silicon or Intel)
+- macOS (Apple Silicon or Intel) or Linux
 - Internet connection
-- Admin privileges (for some cask installations)
+- Admin privileges (for some cask installations on macOS)
 
 ## Notes
 
 - All scripts are idempotent (safe to run multiple times)
 - Scripts will skip already-installed packages
 - Do NOT run with `sudo` - Homebrew doesn't support root installation
+- **Linux Support**: Cask applications (GUI apps) are macOS-only and will be automatically skipped on Linux. Use your distribution's package manager (apt/dnf/pacman) for GUI applications instead

--- a/scripts/03-install-packages.sh
+++ b/scripts/03-install-packages.sh
@@ -25,6 +25,8 @@ while [[ $# -gt 0 ]]; do
       echo "Options:"
       echo "  --dry-run, -n    Preview what would be installed without making changes"
       echo "  --help, -h       Show this help message"
+      echo ""
+      echo "Note: Cask applications are macOS-only and will be skipped on Linux"
       exit 0
       ;;
     *)
@@ -39,6 +41,25 @@ if $DRY_RUN; then
   echo "🔍 DRY RUN MODE - No changes will be made"
   echo ""
 fi
+
+# =============================================================================
+# OS DETECTION
+# =============================================================================
+OS_TYPE="$(uname -s)"
+IS_MACOS=false
+IS_LINUX=false
+
+case "$OS_TYPE" in
+  Darwin)
+    IS_MACOS=true
+    ;;
+  Linux)
+    IS_LINUX=true
+    ;;
+  *)
+    echo "⚠️  Unknown OS: $OS_TYPE - proceeding with caution"
+    ;;
+esac
 
 # =============================================================================
 # SECURITY CHECK
@@ -159,26 +180,32 @@ for formula in "${formulae[@]}"; do
 done
 
 # =============================================================================
-# INSTALL CASK APPLICATIONS
+# INSTALL CASK APPLICATIONS (macOS only)
 # =============================================================================
-echo ""
-echo "🖥️  Cask applications (GUI apps)..."
-echo "   Total: ${#cask_apps[@]} applications"
-echo ""
+if $IS_LINUX; then
+  echo ""
+  echo "🐧 Skipping cask applications on Linux (macOS-only feature)"
+  echo "   Formulae have been installed. Consider apt/dnf/pacman for GUI apps."
+else
+  echo ""
+  echo "🖥️  Cask applications (GUI apps)..."
+  echo "   Total: ${#cask_apps[@]} applications"
+  echo ""
 
-for app in "${cask_apps[@]}"; do
-  # Extract app name (remove inline comments)
-  app_name=$(echo "$app" | awk '{print $1}')
+  for app in "${cask_apps[@]}"; do
+    # Extract app name (remove inline comments)
+    app_name=$(echo "$app" | awk '{print $1}')
 
-  if brew list --cask "$app_name" &>/dev/null; then
-    echo "  ✅ $app_name (already installed)"
-  elif $DRY_RUN; then
-    echo "  📋 $app_name (would install)"
-  else
-    echo "  ⬇️  Installing $app_name..."
-    brew install --cask "$app_name"
-  fi
-done
+    if brew list --cask "$app_name" &>/dev/null; then
+      echo "  ✅ $app_name (already installed)"
+    elif $DRY_RUN; then
+      echo "  📋 $app_name (would install)"
+    else
+      echo "  ⬇️  Installing $app_name..."
+      brew install --cask "$app_name"
+    fi
+  done
+fi
 
 # =============================================================================
 # SUMMARY


### PR DESCRIPTION
## Summary

Adds Linux support to brew-up with automatic OS detection. The package installation script now detects the operating system and automatically skips macOS-only cask applications when running on Linux.

## Changes

- **OS Detection**: Added automatic OS detection using `uname -s` to identify Darwin (macOS) vs Linux
- **Conditional Cask Installation**: Cask applications are now skipped on Linux with a helpful message directing users to their distribution's package manager (apt/dnf/pacman)
- **Updated Help Text**: Added note about Linux compatibility to the `--help` output
- **Documentation Updates**: Updated README.md to reflect Linux support and explain the cask behavior difference

## Technical Details

The script now sets `IS_MACOS` and `IS_LINUX` boolean flags based on the detected OS type. The cask installation section is wrapped in a conditional that:
- On macOS: Installs casks as normal
- On Linux: Skips casks entirely and shows informative message

All formulae (CLI tools) continue to install on both platforms, as Homebrew for Linux supports these packages.

## Testing

- Syntax validation passed: `bash -n scripts/03-install-packages.sh`
- Logic verified for both OS paths

## Platform Compatibility

- macOS (Apple Silicon/Intel): Full support (formulae + casks)
- Linux: Formulae only (casks automatically skipped)