### PR TITLE
feat: add confirmation prompt before installing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ Preview what would be installed without making changes:
 ./setup.sh -n
 ```
 
+### Skip Confirmation (Automation)
+
+For CI/CD or automation, skip the interactive confirmation prompt:
+
+```bash
+./setup.sh --yes
+# or
+./setup.sh -y
+```
+
 ### Individual Scripts
 
 Run specific setup steps:
@@ -128,4 +138,5 @@ To add or remove packages, edit `scripts/03-install-packages.sh`:
 
 - All scripts are idempotent (safe to run multiple times)
 - Scripts will skip already-installed packages
+- Interactive confirmation prompt before installing (use `--yes` to skip)
 - Do NOT run with `sudo` - Homebrew doesn't support root installation

--- a/scripts/03-install-packages.sh
+++ b/scripts/03-install-packages.sh
@@ -12,6 +12,7 @@ set -e
 # PARSE ARGUMENTS
 # =============================================================================
 DRY_RUN=false
+AUTO_CONFIRM=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -19,11 +20,16 @@ while [[ $# -gt 0 ]]; do
       DRY_RUN=true
       shift
       ;;
+    --yes|-y)
+      AUTO_CONFIRM=true
+      shift
+      ;;
     --help|-h)
       echo "Usage: $0 [OPTIONS]"
       echo ""
       echo "Options:"
       echo "  --dry-run, -n    Preview what would be installed without making changes"
+      echo "  --yes, -y        Skip confirmation prompt (for automation)"
       echo "  --help, -h       Show this help message"
       exit 0
       ;;
@@ -135,6 +141,47 @@ cask_apps=(
   # Security
   mozilla-vpn               # VPN client
 )
+
+# =============================================================================
+# CONFIRMATION PROMPT
+# =============================================================================
+if ! $DRY_RUN && ! $AUTO_CONFIRM; then
+  # Count what will be installed
+  to_install_formulae=0
+  to_install_casks=0
+
+  for formula in "${formulae[@]}"; do
+    formula_name=$(echo "$formula" | awk '{print $1}')
+    if ! brew list "$formula_name" &>/dev/null; then
+      ((to_install_formulae++)) || true
+    fi
+  done
+
+  for app in "${cask_apps[@]}"; do
+    app_name=$(echo "$app" | awk '{print $1}')
+    if ! brew list --cask "$app_name" &>/dev/null; then
+      ((to_install_casks++)) || true
+    fi
+  done
+
+  if [[ $to_install_formulae -gt 0 || $to_install_casks -gt 0 ]]; then
+    echo ""
+    echo "📋 Will install:"
+    echo "   - $to_install_formulae formulae"
+    echo "   - $to_install_casks cask applications"
+    echo ""
+    read -p "Proceed with installation? [y/N] " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+      echo "❌ Installation cancelled"
+      exit 0
+    fi
+  else
+    echo ""
+    echo "✅ All packages already installed!"
+    exit 0
+  fi
+fi
 
 # =============================================================================
 # INSTALL FORMULAE

--- a/setup.sh
+++ b/setup.sh
@@ -11,12 +11,14 @@
 #   ./setup.sh              # Full setup
 #   ./setup.sh --dry-run    # Preview package installations
 #   ./setup.sh -n           # Short form of --dry-run
+#   ./setup.sh --yes        # Skip confirmation prompt
 # =============================================================================
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DRY_RUN=""
+AUTO_CONFIRM=""
 
 # =============================================================================
 # PARSE ARGUMENTS
@@ -27,6 +29,10 @@ while [[ $# -gt 0 ]]; do
       DRY_RUN="--dry-run"
       shift
       ;;
+    --yes|-y)
+      AUTO_CONFIRM="--yes"
+      shift
+      ;;
     --help|-h)
       echo "Usage: $0 [OPTIONS]"
       echo ""
@@ -34,12 +40,13 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Options:"
       echo "  --dry-run, -n    Preview package installations without making changes"
+      echo "  --yes, -y        Skip confirmation prompt (for automation)"
       echo "  --help, -h       Show this help message"
       echo ""
       echo "Individual scripts:"
       echo "  ./scripts/01-install-homebrew.sh   Install Homebrew only"
       echo "  ./scripts/02-install-ohmyzsh.sh    Install Oh My Zsh only"
-      echo "  ./scripts/03-install-packages.sh   Install packages only (supports --dry-run)"
+      echo "  ./scripts/03-install-packages.sh   Install packages only (supports --dry-run, --yes)"
       exit 0
       ;;
     *)
@@ -87,7 +94,7 @@ echo ""
 # Step 3: Install Packages
 echo "📋 Step 3/3: Packages"
 echo "----------------------------------------"
-"$SCRIPT_DIR/scripts/03-install-packages.sh" $DRY_RUN
+"$SCRIPT_DIR/scripts/03-install-packages.sh" $DRY_RUN $AUTO_CONFIRM
 echo ""
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds an interactive confirmation prompt before installing packages, with an option to skip for automation.

### Changes

- **Confirmation prompt**: Before installing, shows how many formulae and casks will be installed and asks for confirmation
- **`--yes`/`-y` flag**: Skip confirmation prompt for CI/CD and automation scripts
- **Early exit**: If all packages are already installed, exits with success message instead of running empty install loops
- **setup.sh updated**: Passes `--yes` flag through to packages script

### Usage

```bash
# Interactive (shows confirmation)
./setup.sh

# Skip confirmation (for automation)
./setup.sh --yes
./setup.sh -y

# Combine with dry-run
./setup.sh --dry-run  # No confirmation needed (preview only)
```

### Example Output

```
📋 Will install:
   - 6 formulae
   - 4 cask applications

Proceed with installation? [y/N]
```

## Test Plan

- [x] Syntax check passes for all scripts
- [x] `--yes` flag skips confirmation
- [x] Default behavior prompts for confirmation
- [x] Early exit when all packages installed