### PR TITLE
feat: add post-install config and update packages

### DIFF
--- a/scripts/03-install-packages.sh
+++ b/scripts/03-install-packages.sh
@@ -141,15 +141,16 @@ cask_apps=(
   brave-browser             # Chrome-based browser
   chromium                  # Open-source browser
   firefox                   # Mozilla Firefox
-  zen-browser               # Privacy-focused browser
+  zen                       # Privacy-focused browser
 
   # Productivity
+  bettertouchtool           # Keyboard/mouse customization
   iterm2                    # Terminal emulator
 
   # System Utilities
   appcleaner                # App uninstaller
   istat-menus               # System monitor menubar
-  jordanbaird-ice           # Menubar manager
+  jordanbaird-ice@beta      # Menubar manager
   jump-desktop-connect      # Remote desktop client
   linearmouse               # Mouse customization
   little-snitch             # Network monitor

--- a/scripts/04-post-install-config.sh
+++ b/scripts/04-post-install-config.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# =============================================================================
+# Post-Install Configuration Script
+# =============================================================================
+# Applies standard configurations after package installation
+# Idempotent - safe to run multiple times
+# =============================================================================
+
+set -e
+
+# Security check
+if [[ $EUID -eq 0 ]]; then
+  echo "ERROR: Do not run this script as root/sudo"
+  exit 1
+fi
+
+echo "Applying post-install configurations..."
+echo ""
+
+# =============================================================================
+# GIT CONFIGURATION
+# =============================================================================
+echo "--- Git Configuration ---"
+
+if ! git config --global user.name &>/dev/null; then
+  echo "  Git user.name not configured. Set with:"
+  echo "    git config --global user.name 'Your Name'"
+else
+  echo "  user.name: $(git config --global user.name)"
+fi
+
+if ! git config --global user.email &>/dev/null; then
+  echo "  Git user.email not configured. Set with:"
+  echo "    git config --global user.email 'your@email.com'"
+else
+  echo "  user.email: $(git config --global user.email)"
+fi
+
+# =============================================================================
+# 1PASSWORD SSH AGENT
+# =============================================================================
+echo ""
+echo "--- 1Password SSH Agent ---"
+
+SSH_CONFIG="$HOME/.ssh/config"
+mkdir -p "$HOME/.ssh"
+
+if [[ ! -f "$SSH_CONFIG" ]] || ! grep -q "IdentityAgent" "$SSH_CONFIG"; then
+  echo "  Configuring SSH for 1Password agent..."
+  cat >> "$SSH_CONFIG" << 'EOF'
+
+# 1Password SSH Agent
+Host *
+    IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+EOF
+  chmod 600 "$SSH_CONFIG"
+  echo "  SSH configured for 1Password agent"
+else
+  echo "  Already configured"
+fi
+
+# =============================================================================
+# GITHUB CLI
+# =============================================================================
+echo ""
+echo "--- GitHub CLI ---"
+
+if command -v gh &>/dev/null; then
+  if gh auth status &>/dev/null; then
+    echo "  Already authenticated as: $(gh auth status 2>&1 | grep 'Logged in' | head -1 | sed 's/.*as //' | sed 's/ .*//')"
+  else
+    echo "  GitHub CLI not authenticated."
+    read -p "  Would you like to authenticate now? [y/N] " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      gh auth login
+      gh auth setup-git
+      echo "  GitHub CLI configured"
+    else
+      echo "  Skipped. Run 'gh auth login' later to authenticate."
+    fi
+  fi
+else
+  echo "  gh not installed (will be available after brew packages install)"
+fi
+
+# =============================================================================
+# ZSH PLUGINS
+# =============================================================================
+echo ""
+echo "--- Zsh Plugins ---"
+
+ZSHRC="$HOME/.zshrc"
+
+if [[ ! -f "$ZSHRC" ]]; then
+  echo "  No .zshrc found. Run Oh My Zsh installer first."
+else
+  PLUGINS_ADDED=false
+
+  if ! grep -q "zsh-autosuggestions.zsh" "$ZSHRC" 2>/dev/null; then
+    echo "" >> "$ZSHRC"
+    echo "# Homebrew zsh plugins" >> "$ZSHRC"
+    echo 'source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh 2>/dev/null' >> "$ZSHRC"
+    PLUGINS_ADDED=true
+    echo "  Added zsh-autosuggestions"
+  fi
+
+  if ! grep -q "zsh-syntax-highlighting.zsh" "$ZSHRC" 2>/dev/null; then
+    if ! $PLUGINS_ADDED; then
+      echo "" >> "$ZSHRC"
+      echo "# Homebrew zsh plugins" >> "$ZSHRC"
+    fi
+    echo 'source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh 2>/dev/null' >> "$ZSHRC"
+    echo "  Added zsh-syntax-highlighting"
+    PLUGINS_ADDED=true
+  fi
+
+  if ! $PLUGINS_ADDED; then
+    echo "  Already configured"
+  fi
+fi
+
+# =============================================================================
+# SUMMARY
+# =============================================================================
+echo ""
+echo "Post-install configuration complete!"
+echo ""
+echo "Manual steps remaining:"
+echo "  1. Enable SSH Agent in 1Password: Settings > Developer > SSH Agent"
+echo "  2. Restart your terminal to apply zsh plugin changes"

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,7 @@
 # 1. Install Homebrew (if not present)
 # 2. Install Oh My Zsh (if not present)
 # 3. Install formulae and casks
+# 4. Apply post-install configurations (SSH, zsh plugins)
 #
 # Usage:
 #   ./setup.sh              # Full setup
@@ -44,9 +45,10 @@ while [[ $# -gt 0 ]]; do
       echo "  --help, -h       Show this help message"
       echo ""
       echo "Individual scripts:"
-      echo "  ./scripts/01-install-homebrew.sh   Install Homebrew only"
-      echo "  ./scripts/02-install-ohmyzsh.sh    Install Oh My Zsh only"
-      echo "  ./scripts/03-install-packages.sh   Install packages only (supports --dry-run, --yes)"
+      echo "  ./scripts/01-install-homebrew.sh     Install Homebrew only"
+      echo "  ./scripts/02-install-ohmyzsh.sh      Install Oh My Zsh only"
+      echo "  ./scripts/03-install-packages.sh     Install packages only (supports --dry-run, --yes)"
+      echo "  ./scripts/04-post-install-config.sh  Apply post-install configurations"
       exit 0
       ;;
     *)
@@ -73,7 +75,7 @@ echo "========================================"
 echo ""
 
 # Step 1: Install Homebrew
-echo "📦 Step 1/3: Homebrew"
+echo "Step 1/4: Homebrew"
 echo "----------------------------------------"
 "$SCRIPT_DIR/scripts/01-install-homebrew.sh"
 echo ""
@@ -86,16 +88,27 @@ elif [[ -d /usr/local/Homebrew ]]; then
 fi
 
 # Step 2: Install Oh My Zsh
-echo "🎨 Step 2/3: Oh My Zsh"
+echo "Step 2/4: Oh My Zsh"
 echo "----------------------------------------"
 "$SCRIPT_DIR/scripts/02-install-ohmyzsh.sh"
 echo ""
 
 # Step 3: Install Packages
-echo "📋 Step 3/3: Packages"
+echo "Step 3/4: Packages"
 echo "----------------------------------------"
 "$SCRIPT_DIR/scripts/03-install-packages.sh" $DRY_RUN $AUTO_CONFIRM
 echo ""
+
+# Step 4: Post-install Configuration
+if [[ -z "$DRY_RUN" ]]; then
+  echo "Step 4/4: Post-install Configuration"
+  echo "----------------------------------------"
+  "$SCRIPT_DIR/scripts/04-post-install-config.sh"
+  echo ""
+else
+  echo "Step 4/4: Post-install Configuration (skipped in dry-run)"
+  echo ""
+fi
 
 # =============================================================================
 # COMPLETE
@@ -103,10 +116,10 @@ echo ""
 echo "========================================"
 echo "🎉 Setup complete!"
 echo ""
-echo "💡 Next steps:"
-echo "   1. Restart your terminal for all changes to take effect"
-echo "   2. Explore Oh My Zsh themes: ~/.oh-my-zsh/themes/"
-echo "   3. Configure your apps as needed"
+echo "Next steps:"
+echo "  1. Restart your terminal for all changes to take effect"
+echo "  2. Enable SSH Agent in 1Password: Settings > Developer > SSH Agent"
+echo "  3. Configure your apps as needed"
 echo ""
 if [[ -n "$DRY_RUN" ]]; then
   echo "📋 Note: Packages were previewed only (--dry-run mode)"


### PR DESCRIPTION
## Summary
- Add `04-post-install-config.sh` for SSH and zsh plugin configuration
- Add bettertouchtool to cask list
- Fix zen-browser cask name to `zen`
- Update `setup.sh` to include post-install step (4/4)

## Changes
- **scripts/03-install-packages.sh**: Added bettertouchtool, fixed zen cask name
- **scripts/04-post-install-config.sh**: New script that configures 1Password SSH agent and sources zsh plugins
- **setup.sh**: Now runs 4 steps instead of 3, includes post-install config

## Test plan
- [ ] Run `./setup.sh --dry-run` to verify package list
- [ ] Run `./scripts/04-post-install-config.sh` to verify idempotent config